### PR TITLE
Publish to Gradle Plugin Portal (1.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
+## 1.0.2
 
+- Published to [Gradle Plugin Portal](https://plugins.gradle.org/plugin/at.phatbl.shellexec) #27
 
 ## 1.0.1
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -233,7 +233,7 @@ bintray {
     key = property("bintray.api.key") as String
     setPublications("mavenJava")
     setConfigurations("archives")
-    dryRun = true
+    dryRun = false
     publish = true
     pkg.apply {
         repo = "maven-open-source"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ import org.junit.platform.gradle.plugin.JUnitPlatformExtension
 /* -------------------------------------------------------------------------- */
 
 group = "at.phatbl"
-version = "1.0.1"
+version = "1.0.2"
 
 val artifactName = "shellexec"
 val javaPackage = "$group.$artifactName"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -265,4 +265,5 @@ val deploy by tasks.creating {
     description = "Deploys the artifact."
     group = "Deployment"
     dependsOn("bintrayUpload")
+    dependsOn("publishPlugins")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ import build.junitPlatform
 import com.jfrog.bintray.gradle.BintrayExtension
 import java.util.Date
 import org.gradle.api.tasks.wrapper.Wrapper.DistributionType
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.extra
 import org.gradle.kotlin.dsl.kotlin
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -60,7 +61,8 @@ plugins {
     kotlin("jvm")
 
     // Gradle plugin portal - https://plugins.gradle.org/
-    id("com.jfrog.bintray") //version "1.8.0"
+    id("com.gradle.plugin-publish") version  "0.9.9"
+    id("com.jfrog.bintray") // version "1.8.0"
 }
 
 apply {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -203,6 +203,18 @@ gradlePlugin.plugins.create(artifactName) {
     implementationClass = "$javaPackage.$pluginClass"
 }
 
+pluginBundle {
+    website = "https://github.com/phatblat/ShellExec"
+    vcsUrl = "https://github.com/phatblat/ShellExec"
+    description = "Exec base task alternative which runs commands in a Bash shell."
+    tags = mutableListOf("gradle", "exec", "shell", "bash", "kotlin")
+
+    plugins.create("shellexec") {
+        id = javaPackage
+        displayName = "ShellExec"
+    }
+}
+
 publishing {
     (publications) {
         "mavenJava"(MavenPublication::class) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -199,7 +199,7 @@ configure<BasePluginConvention> {
 }
 
 gradlePlugin.plugins.create(artifactName) {
-    id = artifactName
+    id = javaPackage
     implementationClass = "$javaPackage.$pluginClass"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ version = "1.0.1"
 
 val artifactName = "shellexec"
 val javaPackage = "$group.$artifactName"
-val pluginClass =  "${name}Plugin"
+val pluginClass =  "ShellExecPlugin"
 
 val kotlinVersion: String by extra
 project.logger.lifecycle("kotlinVersion: $kotlinVersion")
@@ -211,8 +211,9 @@ pluginBundle {
 
     plugins.create("shellexec") {
         id = javaPackage
-        displayName = "ShellExec"
+        displayName = "ShellExec plugin"
     }
+    mavenCoordinates.artifactId = artifactName
 }
 
 publishing {

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,4 @@
  * ShellExec
  */
 
-rootProject.name = 'ShellExec'
+rootProject.name = 'shellexec'


### PR DESCRIPTION
Docs:
- https://plugins.gradle.org/docs/submit
- https://plugins.gradle.org/docs/publish-plugin

ShellExec is now live on the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/at.phatbl.shellexec).