### PR TITLE
Erik/stdout fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- 📝 Fixed string version of standard output from commands #47
 - ⬆️🐘 Gradle (4.7) #46
 - ⬆️ Kotlin (1.2.41) #46
 - ⬆️ JUnit Platform (1.2.0) #46

--- a/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
+++ b/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
@@ -40,6 +40,8 @@ data class ShellCommand(
     val failed: Boolean
         get() = !succeeded
 
+    var readLimit = bufferSize
+
     /**
      * Runs the command.
      */
@@ -48,8 +50,8 @@ data class ShellCommand(
         val pb = ProcessBuilder("bash", "-c", "cd '$baseDir' && $command")
         process = pb.start()
 
-        process.inputStream.mark(bufferSize)
-        process.errorStream.mark(bufferSize)
+        process.inputStream.mark(readLimit)
+        process.errorStream.mark(readLimit)
 
         if (standardOutput != null) {
             copy(input = process.inputStream, output = standardOutput!!)
@@ -62,7 +64,7 @@ data class ShellCommand(
             process.inputStream.reset()
         } catch (e: Exception) {
             if (standardOutput != null) {
-                val errorMessage = "Could not reset input stream. Mark with Readlimit $bufferSize not found.".toByteArray()
+                val errorMessage = "Could not reset input stream. Mark with Readlimit $readLimit not found.".toByteArray()
                 standardOutput!!.write(errorMessage)
             }
         }
@@ -71,7 +73,7 @@ data class ShellCommand(
             process.errorStream.reset()
         } catch (e: Exception) {
             if (errorOutput != null) {
-                val errorMessage = "Could not reset error stream. Mark with Readlimit $bufferSize not found.".toByteArray()
+                val errorMessage = "Could not reset error stream. Mark with Readlimit $readLimit not found.".toByteArray()
                 errorOutput!!.write(errorMessage)
             }
         }

--- a/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
+++ b/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
@@ -48,7 +48,7 @@ data class ShellCommand(
         val pb = ProcessBuilder("bash", "-c", "cd '$baseDir' && $command")
         process = pb.start()
 
-        process.inputStream.mark(bufferSize)
+        process.inputStream.mark(10)
         process.errorStream.mark(bufferSize)
 
         if (standardOutput != null) {
@@ -61,13 +61,19 @@ data class ShellCommand(
         try {
             process.inputStream.reset()
         } catch (e: Exception) {
-            // TODO: Get a useful message back to the outputStream
+            if (standardOutput != null) {
+                val errorMessage = "Could not reset input stream. Mark with Readlimit $bufferSize not found.".toByteArray()
+                standardOutput!!.write(errorMessage)
+            }
         }
 
         try {
             process.errorStream.reset()
         } catch (e: Exception) {
-            // TODO: Get a useful message back to the outputStream
+            if (errorOutput != null) {
+                val errorMessage = "Could not reset error stream. Mark with Readlimit $bufferSize not found.".toByteArray()
+                errorOutput!!.write(errorMessage)
+            }
         }
 
         process.waitFor(timeout, TimeUnit.SECONDS)

--- a/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
+++ b/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
@@ -26,10 +26,10 @@ data class ShellCommand(
     var errorOutput: OutputStream? = null
 //    val standardInput: InputStream
 
-    val stdout: String?
+    val stdout: String
         get() = stream2String(process.inputStream)
 
-    val stderr: String?
+    val stderr: String
         get() = stream2String(process.errorStream)
 
     var exitValue: Int = uninitializedExitValue
@@ -48,7 +48,7 @@ data class ShellCommand(
         val pb = ProcessBuilder("bash", "-c", "cd '$baseDir' && $command")
         process = pb.start()
 
-        process.inputStream.mark(10)
+        process.inputStream.mark(bufferSize)
         process.errorStream.mark(bufferSize)
 
         if (standardOutput != null) {
@@ -83,7 +83,7 @@ data class ShellCommand(
     /**
      * Utility function which converts an input stream into a string.
      */
-    private fun stream2String(stream: InputStream): String? {
+    private fun stream2String(stream: InputStream): String {
         return try {
             val reader = BufferedReader(InputStreamReader(stream))
             val builder = StringBuilder()
@@ -95,7 +95,7 @@ data class ShellCommand(
 
             builder.toString()
         } catch (e: Exception) {
-            null
+            return ""
         }
     }
 

--- a/src/main/kotlin/at.phatbl.shellexec/ShellExec.kt
+++ b/src/main/kotlin/at.phatbl.shellexec/ShellExec.kt
@@ -41,7 +41,7 @@ open class ShellExec: DefaultTask() {
     var exitValue: Int = -999
         get() = shellCommand.exitValue
 
-    private lateinit var shellCommand: ShellCommand
+    open lateinit var shellCommand: ShellCommand
 
     /** Core storage of command line to be executed */
     @Input

--- a/src/main/kotlin/at.phatbl.shellexec/ShellExec.kt
+++ b/src/main/kotlin/at.phatbl.shellexec/ShellExec.kt
@@ -91,6 +91,12 @@ open class ShellExec: DefaultTask() {
         }
 
         postExec()
+
+        // Close up all the streams as we are done using shell exec
+        shellCommand.process.inputStream.close()
+        shellCommand.process.errorStream.close()
+        standardOutput.close()
+        errorOutput.close()
     }
 
     /** Hook for running logic before the exec task action runs. */

--- a/src/test/kotlin/at.phatbl.shellexec/ShellCommandSpek.kt
+++ b/src/test/kotlin/at.phatbl.shellexec/ShellCommandSpek.kt
@@ -14,6 +14,7 @@ object ShellCommandSpek : Spek({
         var shellCommand: ShellCommand
         beforeEachTest {
         }
+
         it("can run a simple command") {
             shellCommand = ShellCommand(baseDir = File("."), command = "true")
             shellCommand.start()
@@ -22,6 +23,7 @@ object ShellCommandSpek : Spek({
             assertFalse(shellCommand.failed)
             assertEquals(0, shellCommand.exitValue)
         }
+
         it("can run a failing command") {
             shellCommand = ShellCommand(baseDir = File("."), command = "false")
             shellCommand.start()
@@ -30,6 +32,7 @@ object ShellCommandSpek : Spek({
             assertFalse(shellCommand.succeeded)
             assertEquals(1, shellCommand.exitValue)
         }
+
         it("can generate standard output") {
             shellCommand = ShellCommand(baseDir = File("."), command = "echo Hello World!")
             shellCommand.start()
@@ -37,6 +40,7 @@ object ShellCommandSpek : Spek({
             assertTrue(shellCommand.succeeded)
             assertEquals("Hello World!\n", shellCommand.stdout)
         }
+
         it("can generate error output") {
             shellCommand = ShellCommand(baseDir = File("."), command = "echo This is an error. >&2")
             shellCommand.start()
@@ -44,6 +48,23 @@ object ShellCommandSpek : Spek({
             assertTrue(shellCommand.succeeded)
             assertEquals("This is an error.\n", shellCommand.stderr)
         }
+
+        it("generate error when standard output is to big") {
+            shellCommand = ShellCommand(baseDir = File("."), command = "echo Hello World!")
+            shellCommand.start()
+
+            assertTrue(shellCommand.succeeded)
+            assertEquals("Hello World!\n", shellCommand.stdout)
+        }
+
+        it("can generate error output") {
+            shellCommand = ShellCommand(baseDir = File("."), command = "echo This is an error. >&2")
+            shellCommand.start()
+
+            assertTrue(shellCommand.succeeded)
+            assertEquals("This is an error.\n", shellCommand.stderr)
+        }
+
         it("can invoke a command with spaces in the path") {
             val fileName = "File with spaces in the name"
             val fileContents = "This is the file contents!"
@@ -70,6 +91,7 @@ object ShellCommandSpek : Spek({
 
             temporaryFolder.delete()
         }
+
         it("can invoke a command with spaces in the current directory") {
             val dirName = "directory with spaces in the name"
             val fileContents = "This is the file contents!"

--- a/src/test/kotlin/at.phatbl.shellexec/ShellCommandSpek.kt
+++ b/src/test/kotlin/at.phatbl.shellexec/ShellCommandSpek.kt
@@ -49,22 +49,6 @@ object ShellCommandSpek : Spek({
             assertEquals("This is an error.\n", shellCommand.stderr)
         }
 
-        it("generate error when standard output is to big") {
-            shellCommand = ShellCommand(baseDir = File("."), command = "echo Hello World!")
-            shellCommand.start()
-
-            assertTrue(shellCommand.succeeded)
-            assertEquals("Hello World!\n", shellCommand.stdout)
-        }
-
-        it("can generate error output") {
-            shellCommand = ShellCommand(baseDir = File("."), command = "echo This is an error. >&2")
-            shellCommand.start()
-
-            assertTrue(shellCommand.succeeded)
-            assertEquals("This is an error.\n", shellCommand.stderr)
-        }
-
         it("can invoke a command with spaces in the path") {
             val fileName = "File with spaces in the name"
             val fileContents = "This is the file contents!"


### PR DESCRIPTION
solves #34 
👍 Added the capability for stdout string to be retrieved as well as outputting to the output stream.

There are several warnings about issues that can occur with this change.
Users looking to use the stdout string should always check to make sure it is not blank as the issues will cause the string to come back blank.
Could get tests to work as getting a buffer large enough to trigger the exception caused the test to stall.