### PR TITLE
⬆️ Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - 📝 Fixed string version of standard output from commands #47
+- ⬆️ Kotlin (1.2.71) #48 
 - ⬆️🐘 Gradle (4.7) #46
 - ⬆️ Kotlin (1.2.41) #46
 - ⬆️ JUnit Platform (1.2.0) #46

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,6 @@ import org.gradle.kotlin.dsl.creating
 import org.gradle.kotlin.dsl.extra
 import org.gradle.kotlin.dsl.kotlin
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.jetbrains.kotlin.preprocessor.mkdirsOrFail
 import org.junit.platform.console.options.Details
 import org.junit.platform.gradle.plugin.EnginesExtension
 import org.junit.platform.gradle.plugin.FiltersExtension
@@ -119,7 +118,7 @@ val updateVersionFile by tasks.creating {
     group = "Build"
     doLast {
         val resources = "src/main/resources"
-        project.file(resources).mkdirsOrFail()
+        project.file(resources).mkdirs()
         val versionFile = project.file("$resources/VERSION.txt")
         versionFile.createNewFile()
         versionFile.writeText(version.toString())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ plugins {
     `maven-publish`
 
     // Gradle plugin portal - https://plugins.gradle.org/
-    kotlin("jvm") version "1.2.41"
+    kotlin("jvm") version "1.2.71"
     id("at.phatbl.clamp") version "1.1.0"
     id("at.phatbl.shellexec") version "1.1.3"
     id("com.gradle.plugin-publish") version "0.9.10"


### PR DESCRIPTION
Kotlin [1.2.71](https://blog.jetbrains.com/kotlin/2018/09/kotlin-1-2-70-is-out/) will probably be the last update before 1.3.