### PR TITLE
♻️ Refactor stdout/stderr convenience properties

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- ♻️ Refactor stdout/stderr convenience properties #56
 - ⬆️ Bintray plugin (1.8.4) #55
 
 ## 1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-- ♻️ Refactor stdout/stderr convenience properties #56
+- ♻️ Refactor `stdout` & `stderr` convenience properties #56
+  - 💥 Return type is now nullable
+  - Output now goes to temp files when not using streams
+  - New `ShellCommandTimeoutException` is thrown with details when a command doesn't complete before the current timeout.
 - ⬆️ Bintray plugin (1.8.4) #55
 
 ## 1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - 💥 Return type is now nullable
   - Output now goes to temp files when not using streams
   - New `ShellCommandTimeoutException` is thrown with details when a command doesn't complete before the current timeout.
+- `baseDir` argument is now optional #56
 - ⬆️ Bintray plugin (1.8.4) #55
 
 ## 1.3.0

--- a/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
+++ b/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
@@ -65,11 +65,11 @@ data class ShellCommand(
         val errorStream = errorOutput
 
         if (outputStream == null) {
-            outputFile = createTempFile("shellexec-", "-output.log", baseDir)
+            outputFile = createTempFile("shellexec-", "-output.log")
             pb.redirectOutput(outputFile)
         }
         if (errorStream == null) {
-            errorFile = createTempFile("shellexec-", "-error.log", baseDir)
+            errorFile = createTempFile("shellexec-", "-error.log")
             pb.redirectError(errorFile)
         }
 

--- a/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
+++ b/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
@@ -124,7 +124,11 @@ data class ShellCommand(
 
         try {
             process.waitFor(timeout, TimeUnit.SECONDS)
-            exitValue = process.exitValue()
+
+            // Check to see if the process has quit. Otherwise calling exitValue throws IllegalThreadStateException
+            if (!process.isAlive) {
+                exitValue = process.exitValue()
+            }
         } catch (e: InterruptedException) {
             val message = "Command timeout, exceeded $timeout second limit."
             throw ShellCommandTimeoutException(message, e)

--- a/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
+++ b/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
@@ -92,16 +92,20 @@ data class ShellCommand(
         }
     }
 
+    /**
+     * Passes characters from the input stream to the output stream.
+     */
     @Throws(IOException::class)
     private fun copy(input: InputStream, output: OutputStream) {
-        try {
-            val buffer = ByteArray(bufferSize)
-            var bytesRead = input.read(buffer)
-            while (bytesRead != -1) {
-                output.write(buffer, 0, bytesRead)
-                bytesRead = input.read(buffer)
+        input.use {
+            output.use {
+                val buffer = ByteArray(bufferSize)
+                var bytesRead = input.read(buffer)
+                while (bytesRead != -1) {
+                    output.write(buffer, 0, bytesRead)
+                    bytesRead = input.read(buffer)
+                }
             }
-            //If needed, close streams.
-        } finally { }
+        }
     }
 }

--- a/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
+++ b/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
@@ -86,9 +86,9 @@ data class ShellCommand(
         try {
             process.waitFor(timeout, TimeUnit.SECONDS)
             exitValue = process.exitValue()
-        } catch (e: Exception) {
-            // Handle timeouts
-            println("ShellCommand timeout: $e")
+        } catch (e: InterruptedException) {
+            val message = "Command timeout, exceeded $timeout second limit."
+            throw ShellCommandTimeoutException(message, e)
         }
     }
 

--- a/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
+++ b/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
@@ -29,15 +29,15 @@ data class ShellCommand(
     private var outputFile: File? = null
     private var errorFile: File? = null
 
-    val stdout: String
+    val stdout: String?
         get() {
-            val output = outputFile ?: return ""
+            val output = outputFile ?: return null
             return output.bufferedReader().use { it.readText() }
         }
 
-    val stderr: String
+    val stderr: String?
         get() {
-            val errors = errorFile ?: return ""
+            val errors = errorFile ?: return null
             return errors.bufferedReader().use { it.readText() }
         }
 

--- a/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
+++ b/src/main/kotlin/at.phatbl.shellexec/ShellCommand.kt
@@ -16,7 +16,7 @@ data class ShellCommand(
         private const val defaultTimeout: Long = 1200
 
         // Used to track whether we've received an updated exit code from the process.
-        private const val uninitializedExitValue = -999
+        const val uninitializedExitValue = -999
 
         private const val bufferSize = 2 * 1024 * 1024
     }
@@ -58,11 +58,11 @@ data class ShellCommand(
     fun start() {
         baseDir.mkdirs()
 
-        val outputStream = standardOutput
-        val errorStream = errorOutput
-
         val pb = ProcessBuilder("bash", "-c", command)
             .directory(baseDir)
+
+        val outputStream = standardOutput
+        val errorStream = errorOutput
 
         if (outputStream == null) {
             outputFile = createTempFile("shellexec-", "-output.log", baseDir)

--- a/src/main/kotlin/at.phatbl.shellexec/ShellCommandTimeoutException.kt
+++ b/src/main/kotlin/at.phatbl.shellexec/ShellCommandTimeoutException.kt
@@ -1,0 +1,9 @@
+package at.phatbl.shellexec
+
+/**
+ * Checked exception thrown when the underlying command's process exceeds the configured timeout.
+ */
+class ShellCommandTimeoutException(
+    message: String,
+    cause: Throwable
+) : Exception(message, cause)

--- a/src/main/kotlin/at.phatbl.shellexec/ShellExec.kt
+++ b/src/main/kotlin/at.phatbl.shellexec/ShellExec.kt
@@ -93,8 +93,6 @@ open class ShellExec: DefaultTask() {
         postExec()
 
         // Close up all the streams as we are done using shell exec
-        shellCommand.process.inputStream.close()
-        shellCommand.process.errorStream.close()
         standardOutput.close()
         errorOutput.close()
     }

--- a/src/main/kotlin/at.phatbl.shellexec/ShellExec.kt
+++ b/src/main/kotlin/at.phatbl.shellexec/ShellExec.kt
@@ -30,10 +30,6 @@ open class ShellExec: DefaultTask() {
     @Internal
     val errorOutput: OutputStream = GradleLogOutputStream(logger, LogLevel.ERROR)
 
-//    @Internal
-//    val standardInput: InputStream
-//        get() = shellCommand.process.outputStream
-
     @Input
     var ignoreExitValue: Boolean = false
 
@@ -41,6 +37,7 @@ open class ShellExec: DefaultTask() {
     var exitValue: Int = -999
         get() = shellCommand.exitValue
 
+    @Internal
     open lateinit var shellCommand: ShellCommand
 
     /** Core storage of command line to be executed */

--- a/src/test/kotlin/at.phatbl.shellexec/ShellCommandSpek.kt
+++ b/src/test/kotlin/at.phatbl.shellexec/ShellCommandSpek.kt
@@ -16,7 +16,7 @@ object ShellCommandSpek : Spek({
         beforeEachTest {}
 
         it("can run a simple command") {
-            shellCommand = ShellCommand(baseDir = File("."), command = "true")
+            shellCommand = ShellCommand(command = "true")
             shellCommand.start()
 
             assertTrue(shellCommand.succeeded)
@@ -25,7 +25,7 @@ object ShellCommandSpek : Spek({
         }
 
         it("can run a failing command") {
-            shellCommand = ShellCommand(baseDir = File("."), command = "false")
+            shellCommand = ShellCommand(command = "false")
             shellCommand.start()
 
             assertTrue(shellCommand.failed)
@@ -34,7 +34,7 @@ object ShellCommandSpek : Spek({
         }
 
         it("can generate standard output") {
-            shellCommand = ShellCommand(baseDir = File("."), command = "echo Hello World!")
+            shellCommand = ShellCommand(command = "echo Hello World!")
             shellCommand.start()
 
             assertTrue(shellCommand.succeeded)
@@ -42,7 +42,7 @@ object ShellCommandSpek : Spek({
         }
 
         it("can generate error output") {
-            shellCommand = ShellCommand(baseDir = File("."), command = "echo This is an error. >&2")
+            shellCommand = ShellCommand(command = "echo This is an error. >&2")
             shellCommand.start()
 
             assertTrue(shellCommand.succeeded)
@@ -71,7 +71,7 @@ object ShellCommandSpek : Spek({
 
             assertTrue(shellCommand.succeeded)
             assertEquals("", stderr)
-            assertEquals("$fileContents", stdout)
+            assertEquals(fileContents, stdout)
 
             temporaryFolder.delete()
         }

--- a/src/test/kotlin/at.phatbl.shellexec/ShellCommandSpek.kt
+++ b/src/test/kotlin/at.phatbl.shellexec/ShellCommandSpek.kt
@@ -4,9 +4,11 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.junit.rules.TemporaryFolder
+import java.io.ByteArrayOutputStream
 import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 object ShellCommandSpek : Spek({
@@ -41,12 +43,36 @@ object ShellCommandSpek : Spek({
             assertEquals("Hello World!\n", shellCommand.stdout)
         }
 
+        it("can generate standard output to a stream") {
+            shellCommand = ShellCommand(command = "echo Hello World!")
+            val stream = ByteArrayOutputStream()
+            shellCommand.standardOutput = stream
+
+            shellCommand.start()
+
+            assertTrue(shellCommand.succeeded)
+            assertEquals("Hello World!\n", String(stream.toByteArray()))
+            assertNull(shellCommand.stdout)
+        }
+
         it("can generate error output") {
             shellCommand = ShellCommand(command = "echo This is an error. >&2")
             shellCommand.start()
 
             assertTrue(shellCommand.succeeded)
             assertEquals("This is an error.\n", shellCommand.stderr)
+        }
+
+        it("can generate error output to a stream") {
+            shellCommand = ShellCommand(command = "echo This is an error. >&2")
+            val stream = ByteArrayOutputStream()
+            shellCommand.errorOutput = stream
+
+            shellCommand.start()
+
+            assertTrue(shellCommand.succeeded)
+            assertEquals("This is an error.\n", String(stream.toByteArray()))
+            assertNull(shellCommand.stderr)
         }
 
         it("can invoke a command with spaces in the path") {

--- a/src/test/kotlin/at.phatbl.shellexec/ShellCommandSpek.kt
+++ b/src/test/kotlin/at.phatbl.shellexec/ShellCommandSpek.kt
@@ -41,6 +41,16 @@ object ShellCommandSpek : Spek({
 
             assertTrue(shellCommand.succeeded)
             assertEquals("Hello World!\n", shellCommand.stdout)
+            assertNull(shellCommand.standardOutput)
+        }
+
+        it("has empty but not null standard output") {
+            shellCommand = ShellCommand(command = "echo -n")
+            shellCommand.start()
+
+            assertTrue(shellCommand.succeeded)
+            assertEquals("", shellCommand.stdout)
+            assertNull(shellCommand.standardOutput)
         }
 
         it("can generate standard output to a stream") {
@@ -61,6 +71,16 @@ object ShellCommandSpek : Spek({
 
             assertTrue(shellCommand.succeeded)
             assertEquals("This is an error.\n", shellCommand.stderr)
+            assertNull(shellCommand.errorOutput)
+        }
+
+        it("has empty but not null error output") {
+            shellCommand = ShellCommand(command = "echo -n >&2")
+            shellCommand.start()
+
+            assertTrue(shellCommand.succeeded)
+            assertEquals("", shellCommand.stderr)
+            assertNull(shellCommand.errorOutput)
         }
 
         it("can generate error output to a stream") {

--- a/src/test/kotlin/at.phatbl.shellexec/ShellCommandSpek.kt
+++ b/src/test/kotlin/at.phatbl.shellexec/ShellCommandSpek.kt
@@ -71,7 +71,7 @@ object ShellCommandSpek : Spek({
 
             assertTrue(shellCommand.succeeded)
             assertEquals("", stderr)
-            assertEquals("$fileContents\n", stdout)
+            assertEquals("$fileContents", stdout)
 
             temporaryFolder.delete()
         }


### PR DESCRIPTION
## Background

The `stdout` and `stderr` convenience properties on `ShellCommand` make it easy for the caller to get back a `String` of the output and any errors from the underlying process without having to set up all the boilerplate to deal with streams. This doesn't allow for continually monitoring output for a long-running process, often simple little commands don't need that.

This creates contention if the caller provides values for the `standardOutput` and `standardError` stream properties because the output gets sent to those streams and nothing is left if the caller _also_ uses the `stdout` and `stderr` convenience properties.

In #47 a fix was applied so that both approaches could be used. The idea is that the streams would be marked so that when the convenience properties were used, the streams would get reset back to that mark and then the content replayed and collected into a string.

The problems with this approach include limitations to how much of the stream can be replayed (affected by the buffer size) but also when using the new timeout control from #54 the underlying `Process` streams can be in an invalid state after an exception is thrown.

## Changes

I've decided to use a different approach to deal with this output in order to simplify the code and make the behavior more reliable. Since there are two different paradigms here `ShellCommand` will use a different approach fo each. Streams are still used if the caller provides them before calling the `start()` method. However, if streams are not provided, output is redirected to temp files using [`ProcessBuilder.redirectOutput`](https://docs.oracle.com/javase/7/docs/api/java/lang/ProcessBuilder.html#redirectOutput(java.lang.ProcessBuilder.Redirect)) and [`redirectError`](https://docs.oracle.com/javase/7/docs/api/java/lang/ProcessBuilder.html#redirectError(java.lang.ProcessBuilder.Redirect)). Then, when the `stdout` and `stderr` convenience properties are accessed, these files are simply read.

The benefits include being able to access the `stdout` and `stderr` content multiple times regardless of the state of the underlying `Process`. These two approaches can even be mixed if the caller wants to stream output but then access errors at the end of the command, for example.

## 💥 API Changes

To reflect the fact that `stdout` and `stderr` aren't usable if a custom `OutputStream` is provided to the `standardOutput` and `errorOutput` properties respectively, these convenience properties are now nullable. There are a limited number of states now after `start()` is called:

- `stdout` is non-null (but could be empty string) when `standardOutput` is null
- `stderr` is non-null (but could be empty string) when `errorOutput` is null
- `stdout` is null when `standardOutput` is non-null
- `stderr` is null when `errorOutput` is non-null

 ### `baseDir`

The `baseDir` argument to `ShellCommand` constructor is no longer required. It will default to the current directory. Note that the current directory is typically the working directory when the JVM was started.