### PR TITLE
Process resources after updating version file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,6 +130,7 @@ val updateVersionFile by tasks.creating {
     }
 }
 
+tasks.getByName("processResources").dependsOn(updateVersionFile)
 tasks.getByName("assemble").dependsOn(updateVersionFile)
 
 val sourcesJar by tasks.creating(Jar::class) {


### PR DESCRIPTION
Hello

This commit fixes a small issue regarding the build of the project.
The task `processResources` must run after `updateVersionFile`, which can potentially change a resource of the project, namely the `VERSION.txt` file.